### PR TITLE
Make email unencrypted

### DIFF
--- a/hole/v1.py
+++ b/hole/v1.py
@@ -102,7 +102,7 @@ class RegisterView(APIView):
                 with open('conf/email.txt', 'a+') as f:
                     f.write(email + ' ')
 
-                email = make_password(email)
+                # email = make_password(email)
                 password = random_str(16)
                 user = User.objects.create_user(username=username, password=password)
                 user.groups.add(1)
@@ -142,7 +142,7 @@ class RegisterView(APIView):
 
             with open('conf/email.txt', 'a+') as f:
                 f.write(email + ' ')
-            email = make_password(email)
+            # email = make_password(email)
             user = User.objects.create_user(username=username, password=password)
             user.groups.add(1)
             user.save()
@@ -491,7 +491,7 @@ class EmailView(APIView):
         email = request.data.get('email')
 
         if profile.has_input_email : return Response({}, status=status.HTTP_400_BAD_REQUEST)
-        if not check_password(email, profile.encrypted_email): return Response({}, status=status.HTTP_400_BAD_REQUEST)
+        if not (email == profile.encrypted_email or check_password(email, profile.encrypted_email)): return Response({}, status=status.HTTP_400_BAD_REQUEST)
 
         profile.has_input_email = True
         profile.save()

--- a/hole/v2.py
+++ b/hole/v2.py
@@ -37,7 +37,7 @@ class RegisterView(APIView):
             if usage == 'change_password':
                 if not User.objects.filter(username=username): return Response({'msg': '用户不存在！'}, status=status.HTTP_404_NOT_FOUND)
                 user = User.objects.get(username=username)
-                if not check_password(email, user.profile.encrypted_email): return Response({'msg': '请使用自己的邮箱'}, status=status.HTTP_400_BAD_REQUEST)
+                if not (email == user.profile.encrypted_email or check_password(email, user.profile.encrypted_email)): return Response({'msg': '请使用自己的邮箱'}, status=status.HTTP_400_BAD_REQUEST)
             else:
                 if User.objects.filter(username=username): return Response({'data': 1, 'msg': '该用户名已注册！'})
 
@@ -105,7 +105,7 @@ class RegisterView(APIView):
                 with open('conf/email.txt', 'a+') as f:
                     f.write(email + ' ')
 
-                email = make_password(email)
+                # email = make_password(email)
                 password = random_str(16)
                 user = User.objects.create_user(username=username, password=password)
                 user.groups.add(1)
@@ -145,7 +145,7 @@ class RegisterView(APIView):
 
             with open('conf/email.txt', 'a+') as f:
                 f.write(email + ' ')
-            email = make_password(email)
+            # email = make_password(email)
             user = User.objects.create_user(username=username, password=password)
             user.groups.add(1)
             user.save()
@@ -529,7 +529,7 @@ class EmailView(APIView):
         email = request.data.get('email')
 
         if profile.has_input_email : return Response({}, status=status.HTTP_400_BAD_REQUEST)
-        if not check_password(email, profile.encrypted_email): return Response({}, status=status.HTTP_400_BAD_REQUEST)
+        if not (email == profile.encrypted_email or check_password(email, profile.encrypted_email)): return Response({}, status=status.HTTP_400_BAD_REQUEST)
 
         profile.has_input_email = True
         profile.save()


### PR DESCRIPTION
Make the email field unencrypted to allow administrators to notify users who registered in the front side with email.

**NOT TESTED -- DO A COMPREHENSIVE INSPECT BEFORE MERGING!**